### PR TITLE
Waf debug release

### DIFF
--- a/exp/example/example.cpp
+++ b/exp/example/example.cpp
@@ -13,7 +13,7 @@ using namespace sferes::gen::evo_float;
 
 struct Params {
   struct evo_float {
-
+    SFERES_CONST float cross_rate = 0.1f;
     SFERES_CONST float mutation_rate = 0.1f;
     SFERES_CONST float eta_m = 15.0f;
     SFERES_CONST float eta_c = 10.0f;

--- a/exp/example/wscript
+++ b/exp/example/wscript
@@ -7,10 +7,9 @@ def options(opt):
     pass
 
 def build(bld):
-    obj = bld.new_task_gen('cxx', 'program')
-    obj.source = 'example.cpp'
-    obj.includes = '. ../../'
-    obj.uselib_local = 'sferes2'
-    obj.uselib = ''
-    obj.target = 'example'
-    obj.uselib_local = 'sferes2'
+    bld.program(features = 'cxx',
+                   source = 'example.cpp',
+                   includes = '. ../../',
+                   uselib = 'EIGEN BOOST BOOST_UNIT_TEST_FRAMEWORK TBB ',
+                   use = 'sferes2',
+                   target = 'example')

--- a/wscript
+++ b/wscript
@@ -102,7 +102,7 @@ def configure(conf):
     conf.load('compiler_cxx')
 
     common_flags = "-D_REENTRANT -Wall -fPIC -ftemplate-depth-1024 -Wno-sign-compare -Wno-deprecated  -Wno-unused "
-    if conf.options.cpp11 and conf.options.cpp11 == 'yes':
+    if not conf.options.cpp11 or conf.options.cpp11 == 'yes':
         common_flags += '-std=c++11 '
 
     # boost

--- a/wscript
+++ b/wscript
@@ -86,8 +86,12 @@ def options(opt):
         opt.recurse(i)
 
     for i in glob.glob('exp/*'):
-        print 'options for exp : [' + i + ']'
-        opt.recurse(i)
+        print 'options for exp : [' + i + ']',
+        try:
+            opt.recurse(i)
+            print 'ok'
+        except:
+            print 'none'
 
 
 def configure(conf):


### PR DESCRIPTION
Put the debug option back. The system is different: now, you need to do ./waf --debug=yes to compile with the debug symbols. This means that the compilation will be twice faster (but the debug version will not be always available).

Be careful that the non-debug version ignore the asserts!