### PR TITLE
fix for empty archive

### DIFF
--- a/sferes/stat/best_archive_fit.hpp
+++ b/sferes/stat/best_archive_fit.hpp
@@ -53,7 +53,7 @@ namespace sferes {
       void refresh(const E& ea) {
         assert(!ea.pop().empty());
 
-        if (ea.template fit_modifier<0>().archive().size() == 0)
+        if (ea.template fit_modifier<0>().archive().empty())
           return;
 
         _best = *std::max_element(

--- a/sferes/stat/best_archive_fit.hpp
+++ b/sferes/stat/best_archive_fit.hpp
@@ -52,6 +52,10 @@ namespace sferes {
       template<typename E>
       void refresh(const E& ea) {
         assert(!ea.pop().empty());
+
+        if (ea.template fit_modifier<0>().archive().size() == 0)
+          return;
+
         _best = *std::max_element(
             ea.template fit_modifier<0>().archive().begin(),
             ea.template fit_modifier<0>().archive().end(),


### PR DESCRIPTION
I suggest the following change, as without it I got a segmentation fault when the archive was empty. 

The "downside" is that the best_archive_fit.dat will not contain any entries about the generations for which the archive was empty. I don't why this would be a problem though.

What do you think? Do you suggest a better way to handle that?