### PR TITLE
Lmod autodetect

### DIFF
--- a/waf_tools/boost.py
+++ b/waf_tools/boost.py
@@ -127,13 +127,10 @@ def boost_get_includes(self, *k, **kw):
 	if includes and self.__boost_get_version_file(includes):
 		return includes
 
-        # JH: Automatic detection of boost include path after loading a module on a cluster
-        include_paths = []
-        if 'CPPFLAGS' in os.environ:
-            include_paths += [path[2:] for path in os.environ['CPPFLAGS'].split() if path[0:2] == '-I']
-        include_paths += BOOST_INCLUDES
-        # JH: Automatic detection of boost includes path end
-
+	include_paths = []
+	if 'CPPFLAGS' in os.environ:
+		include_paths += [path[2:] for path in os.environ['CPPFLAGS'].split() if path[0:2] == '-I']
+	include_paths += BOOST_INCLUDES
 	for dir in include_paths:
 		if self.__boost_get_version_file(dir):
 			return dir
@@ -169,14 +166,11 @@ def __boost_get_libs_path(self, *k, **kw):
 		files = path.ant_glob('*boost_*')
 
 	if not libs or not files:
-                #JH: Also check LD_LIBRARY_PATH
-                lib_paths = []
-                if 'LD_LIBRARY_PATH' in os.environ:
-                        lib_paths += os.environ['LD_LIBRARY_PATH'].split(":")
-                lib_paths += BOOST_LIBS
-                #JH: Also check LD_LIBRARY_PATH end
-
-                for dir in lib_paths:
+		lib_paths = []
+		if 'LD_LIBRARY_PATH' in os.environ:
+			lib_paths += os.environ['LD_LIBRARY_PATH'].split(":")
+		lib_paths += BOOST_LIBS
+		for dir in lib_paths:
 			try:
 				path = self.root.find_dir(dir)
 				files = path.ant_glob('*boost_*')
@@ -257,7 +251,6 @@ def check_boost(self, *k, **kw):
 	You can pass the same parameters as the command line (without "--boost-"),
 	but the command line has the priority.
 	"""
-        print "### Checking for boost ###"
 	if not self.env['CXX']:
 		self.fatal('load a c++ compiler first, conf.load("compiler_cxx")')
 

--- a/waf_tools/eigen.py
+++ b/waf_tools/eigen.py
@@ -17,16 +17,16 @@ def options(opt):
 @conf
 def check_eigen(conf):
 	conf.env['EIGEN_FOUND'] = False
-        conf.env.INCLUDES_EIGEN = []
+	conf.env.INCLUDES_EIGEN = []
 	conf.start_msg('Checking for Eigen')
 	if conf.options.eigen:
 		conf.env.INCLUDES_EIGEN += [conf.options.eigen]
 	else:
-            if 'CPPFLAGS' in os.environ:
-                conf.env.INCLUDES_EIGEN += [path[2:] for path in os.environ['CPPFLAGS'].split() if path[0:2] == '-I']
-            conf.env.INCLUDES_EIGEN += ['/usr/include/eigen3',
-                                           '/usr/local/include/eigen3',
-                                           '/usr/include', '/usr/local/include']
+		if 'CPPFLAGS' in os.environ:
+			conf.env.INCLUDES_EIGEN += [path[2:] for path in os.environ['CPPFLAGS'].split() if path[0:2] == '-I']
+			conf.env.INCLUDES_EIGEN += ['/usr/include/eigen3',
+										'/usr/local/include/eigen3',
+										'/usr/include', '/usr/local/include']
 	try:
 		res = conf.find_file('Eigen/Core', conf.env.INCLUDES_EIGEN)
 		conf.end_msg('ok')

--- a/waf_tools/eigen.py
+++ b/waf_tools/eigen.py
@@ -17,12 +17,14 @@ def options(opt):
 @conf
 def check_eigen(conf):
 	conf.env['EIGEN_FOUND'] = False
+        conf.env.INCLUDES_EIGEN = []
 	conf.start_msg('Checking for Eigen')
 	if conf.options.eigen:
-		conf.env.INCLUDES_EIGEN = [conf.options.eigen]
-		conf.env.LIBPATH_EIGEN = [conf.options.eigen]
+		conf.env.INCLUDES_EIGEN += [conf.options.eigen]
 	else:
-		conf.env.INCLUDES_EIGEN = ['/usr/include/eigen3',
+            if 'CPPFLAGS' in os.environ:
+                conf.env.INCLUDES_EIGEN += [path[2:] for path in os.environ['CPPFLAGS'].split() if path[0:2] == '-I']
+            conf.env.INCLUDES_EIGEN += ['/usr/include/eigen3',
                                            '/usr/local/include/eigen3',
                                            '/usr/include', '/usr/local/include']
 	try:

--- a/waf_tools/mpi.py
+++ b/waf_tools/mpi.py
@@ -10,46 +10,46 @@ import os, glob, types
 from waflib.Configure import conf
 
 def options(opt):
-	opt.add_option("--no-mpi",
-			   default=False, action='store_true',
-			   help='disable mpi', dest='no_mpi')
-	opt.add_option('--mpi', type='string', help='path to mpi', dest='mpi')
+    opt.add_option("--no-mpi",
+               default=False, action='store_true',
+               help='disable mpi', dest='no_mpi')
+    opt.add_option('--mpi', type='string', help='path to mpi', dest='mpi')
 
 
 @conf
 def check_mpi(conf):
-	opt = conf.options
+    opt = conf.options
 
-	conf.env['LIB_MPI'] = ''
-	conf.env['MPI_FOUND'] = False
-	conf.env.INCLUDES_MPI = []
-	conf.env.LIBPATH_MPI = []
-	if conf.options.no_mpi :
-		return
-	if conf.options.mpi:
-		conf.env.INCLUDES_MPI += conf.options.mpi + '/include'
-		conf.env.LIBPATH_MPI += conf.options.mpi + '/lib'
-	else:
-		if 'MPI_ROOT' in os.environ:
-			conf.env.INCLUDES_MPI += [os.environ['MPI_ROOT'] +"/include", os.environ['MPI_ROOT'] +"/include64"]
-		elif 'I_MPI_ROOT' in os.environ: 
-			conf.env.INCLUDES_MPI += [os.environ['I_MPI_ROOT'] +"/include", os.environ['I_MPI_ROOT'] +"/include64"]
-		elif 'CPPFLAGS' in os.environ:
-			conf.env.INCLUDES_MPI += [path[2:] for path in os.environ['CPPFLAGS'].split() if path[0:2] == '-I']
-		conf.env.INCLUDES_MPI += ['/usr/include/mpi', '/usr/local/include/mpi', '/usr/include', '/usr/local/include']
-		if 'LD_LIBRARY_PATH' in os.environ:
-			conf.env.LIBPATH_MPI += os.environ['LD_LIBRARY_PATH'].split(":")
-		conf.env.LIBPATH_MPI += ['/usr/lib', '/usr/local/lib', '/usr/lib/openmpi']
+    conf.env['LIB_MPI'] = ''
+    conf.env['MPI_FOUND'] = False
+    conf.env.INCLUDES_MPI = []
+    conf.env.LIBPATH_MPI = []
+    if conf.options.no_mpi :
+        return
+    if conf.options.mpi:
+        conf.env.INCLUDES_MPI += conf.options.mpi + '/include'
+        conf.env.LIBPATH_MPI += conf.options.mpi + '/lib'
+    else:
+        if 'MPI_ROOT' in os.environ:
+            conf.env.INCLUDES_MPI += [os.environ['MPI_ROOT'] +"/include", os.environ['MPI_ROOT'] +"/include64"]
+        elif 'I_MPI_ROOT' in os.environ: 
+            conf.env.INCLUDES_MPI += [os.environ['I_MPI_ROOT'] +"/include", os.environ['I_MPI_ROOT'] +"/include64"]
+        elif 'CPPFLAGS' in os.environ:
+            conf.env.INCLUDES_MPI += [path[2:] for path in os.environ['CPPFLAGS'].split() if path[0:2] == '-I']
+        conf.env.INCLUDES_MPI += ['/usr/include/mpi', '/usr/local/include/mpi', '/usr/include', '/usr/local/include']
+        if 'LD_LIBRARY_PATH' in os.environ:
+            conf.env.LIBPATH_MPI += os.environ['LD_LIBRARY_PATH'].split(":")
+        conf.env.LIBPATH_MPI += ['/usr/lib', '/usr/local/lib', '/usr/lib/openmpi']
 
-	try:
-		conf.start_msg('Checking for MPI include')
-		res = conf.find_file('mpi.h', conf.env.INCLUDES_MPI)
-		conf.end_msg('ok')
-		conf.env['MPI_FOUND'] = True
-		conf.env.LIB_MPI = ['mpi_cxx','mpi']
-	except:
-		conf.end_msg('Not found', 'YELLOW')
-	return 1
+    try:
+        conf.start_msg('Checking for MPI include')
+        res = conf.find_file('mpi.h', conf.env.INCLUDES_MPI)
+        conf.end_msg('ok')
+        conf.env['MPI_FOUND'] = True
+        conf.env.LIB_MPI = ['mpi_cxx','mpi']
+    except:
+        conf.end_msg('Not found', 'YELLOW')
+    return 1
 
 def detect(conf):
-	return detect_mpi(conf)
+    return detect_mpi(conf)

--- a/waf_tools/mpi.py
+++ b/waf_tools/mpi.py
@@ -11,8 +11,8 @@ from waflib.Configure import conf
 
 def options(opt):
 	opt.add_option("--no-mpi",
-		       default=False, action='store_true',
-		       help='disable mpi', dest='no_mpi')
+			   default=False, action='store_true',
+			   help='disable mpi', dest='no_mpi')
 	opt.add_option('--mpi', type='string', help='path to mpi', dest='mpi')
 
 
@@ -22,26 +22,24 @@ def check_mpi(conf):
 
 	conf.env['LIB_MPI'] = ''
 	conf.env['MPI_FOUND'] = False
-        conf.env.INCLUDES_MPI = []
-        conf.env.LIBPATH_MPI = []
+	conf.env.INCLUDES_MPI = []
+	conf.env.LIBPATH_MPI = []
 	if conf.options.no_mpi :
 		return
 	if conf.options.mpi:
 		conf.env.INCLUDES_MPI += conf.options.mpi + '/include'
 		conf.env.LIBPATH_MPI += conf.options.mpi + '/lib'
 	else:
-                # JH: Check CPPFLAGS environment variable for include paths
-                if 'MPI_ROOT' in os.environ:
-                    conf.env.INCLUDES_MPI += [os.environ['MPI_ROOT'] +"/include", os.environ['MPI_ROOT'] +"/include64"]
-                elif 'I_MPI_ROOT' in os.environ: 
-                    conf.env.INCLUDES_MPI += [os.environ['I_MPI_ROOT'] +"/include", os.environ['I_MPI_ROOT'] +"/include64"]
-                elif 'CPPFLAGS' in os.environ:
-                    conf.env.INCLUDES_MPI += [path[2:] for path in os.environ['CPPFLAGS'].split() if path[0:2] == '-I']
-                conf.env.INCLUDES_MPI += ['/usr/include/mpi', '/usr/local/include/mpi', '/usr/include', '/usr/local/include']
-                # JH: Check LD_LIBRARY_PATH for library paths
-                if 'LD_LIBRARY_PATH' in os.environ:
-                    conf.env.LIBPATH_MPI += os.environ['LD_LIBRARY_PATH'].split(":")
-                conf.env.LIBPATH_MPI += ['/usr/lib', '/usr/local/lib', '/usr/lib/openmpi']
+		if 'MPI_ROOT' in os.environ:
+			conf.env.INCLUDES_MPI += [os.environ['MPI_ROOT'] +"/include", os.environ['MPI_ROOT'] +"/include64"]
+		elif 'I_MPI_ROOT' in os.environ: 
+			conf.env.INCLUDES_MPI += [os.environ['I_MPI_ROOT'] +"/include", os.environ['I_MPI_ROOT'] +"/include64"]
+		elif 'CPPFLAGS' in os.environ:
+			conf.env.INCLUDES_MPI += [path[2:] for path in os.environ['CPPFLAGS'].split() if path[0:2] == '-I']
+		conf.env.INCLUDES_MPI += ['/usr/include/mpi', '/usr/local/include/mpi', '/usr/include', '/usr/local/include']
+		if 'LD_LIBRARY_PATH' in os.environ:
+			conf.env.LIBPATH_MPI += os.environ['LD_LIBRARY_PATH'].split(":")
+		conf.env.LIBPATH_MPI += ['/usr/lib', '/usr/local/lib', '/usr/lib/openmpi']
 
 	try:
 		conf.start_msg('Checking for MPI include')

--- a/waf_tools/mpi.py
+++ b/waf_tools/mpi.py
@@ -10,46 +10,46 @@ import os, glob, types
 from waflib.Configure import conf
 
 def options(opt):
-    opt.add_option("--no-mpi",
-               default=False, action='store_true',
-               help='disable mpi', dest='no_mpi')
-    opt.add_option('--mpi', type='string', help='path to mpi', dest='mpi')
+	opt.add_option("--no-mpi",
+					default=False, action='store_true',
+					help='disable mpi', dest='no_mpi')
+	opt.add_option('--mpi', type='string', help='path to mpi', dest='mpi')
 
 
 @conf
 def check_mpi(conf):
-    opt = conf.options
+	opt = conf.options
 
-    conf.env['LIB_MPI'] = ''
-    conf.env['MPI_FOUND'] = False
-    conf.env.INCLUDES_MPI = []
-    conf.env.LIBPATH_MPI = []
-    if conf.options.no_mpi :
-        return
-    if conf.options.mpi:
-        conf.env.INCLUDES_MPI += conf.options.mpi + '/include'
-        conf.env.LIBPATH_MPI += conf.options.mpi + '/lib'
-    else:
-        if 'MPI_ROOT' in os.environ:
-            conf.env.INCLUDES_MPI += [os.environ['MPI_ROOT'] +"/include", os.environ['MPI_ROOT'] +"/include64"]
-        elif 'I_MPI_ROOT' in os.environ: 
-            conf.env.INCLUDES_MPI += [os.environ['I_MPI_ROOT'] +"/include", os.environ['I_MPI_ROOT'] +"/include64"]
-        elif 'CPPFLAGS' in os.environ:
-            conf.env.INCLUDES_MPI += [path[2:] for path in os.environ['CPPFLAGS'].split() if path[0:2] == '-I']
-        conf.env.INCLUDES_MPI += ['/usr/include/mpi', '/usr/local/include/mpi', '/usr/include', '/usr/local/include']
-        if 'LD_LIBRARY_PATH' in os.environ:
-            conf.env.LIBPATH_MPI += os.environ['LD_LIBRARY_PATH'].split(":")
-        conf.env.LIBPATH_MPI += ['/usr/lib', '/usr/local/lib', '/usr/lib/openmpi']
+	conf.env['LIB_MPI'] = ''
+	conf.env['MPI_FOUND'] = False
+	conf.env.INCLUDES_MPI = []
+	conf.env.LIBPATH_MPI = []
+	if conf.options.no_mpi :
+		return
+	if conf.options.mpi:
+		conf.env.INCLUDES_MPI += conf.options.mpi + '/include'
+		conf.env.LIBPATH_MPI += conf.options.mpi + '/lib'
+	else:
+		if 'MPI_ROOT' in os.environ:
+			conf.env.INCLUDES_MPI += [os.environ['MPI_ROOT'] +"/include", os.environ['MPI_ROOT'] +"/include64"]
+		elif 'I_MPI_ROOT' in os.environ: 
+			conf.env.INCLUDES_MPI += [os.environ['I_MPI_ROOT'] +"/include", os.environ['I_MPI_ROOT'] +"/include64"]
+		elif 'CPPFLAGS' in os.environ:
+			conf.env.INCLUDES_MPI += [path[2:] for path in os.environ['CPPFLAGS'].split() if path[0:2] == '-I']
+		conf.env.INCLUDES_MPI += ['/usr/include/mpi', '/usr/local/include/mpi', '/usr/include', '/usr/local/include']
+		if 'LD_LIBRARY_PATH' in os.environ:
+			conf.env.LIBPATH_MPI += os.environ['LD_LIBRARY_PATH'].split(":")
+		conf.env.LIBPATH_MPI += ['/usr/lib', '/usr/local/lib', '/usr/lib/openmpi']
 
-    try:
-        conf.start_msg('Checking for MPI include')
-        res = conf.find_file('mpi.h', conf.env.INCLUDES_MPI)
-        conf.end_msg('ok')
-        conf.env['MPI_FOUND'] = True
-        conf.env.LIB_MPI = ['mpi_cxx','mpi']
-    except:
-        conf.end_msg('Not found', 'YELLOW')
-    return 1
+	try:
+		conf.start_msg('Checking for MPI include')
+		res = conf.find_file('mpi.h', conf.env.INCLUDES_MPI)
+		conf.end_msg('ok')
+		conf.env['MPI_FOUND'] = True
+		conf.env.LIB_MPI = ['mpi_cxx','mpi']
+	except:
+		conf.end_msg('Not found', 'YELLOW')
+	return 1
 
 def detect(conf):
-    return detect_mpi(conf)
+	return detect_mpi(conf)

--- a/waf_tools/mpi.py
+++ b/waf_tools/mpi.py
@@ -22,14 +22,26 @@ def check_mpi(conf):
 
 	conf.env['LIB_MPI'] = ''
 	conf.env['MPI_FOUND'] = False
+        conf.env.INCLUDES_MPI = []
+        conf.env.LIBPATH_MPI = []
 	if conf.options.no_mpi :
 		return
 	if conf.options.mpi:
-		conf.env.INCLUDES_MPI = conf.options.mpi + '/include'
-		conf.env.LIBPATH_MPI = conf.options.mpi + '/lib'
+		conf.env.INCLUDES_MPI += conf.options.mpi + '/include'
+		conf.env.LIBPATH_MPI += conf.options.mpi + '/lib'
 	else:
-		conf.env.INCLUDES_MPI = ['/usr/include/mpi', '/usr/local/include/mpi', '/usr/include', '/usr/local/include']
-		conf.env.LIBPATH_MPI = ['/usr/lib', '/usr/local/lib', '/usr/lib/openmpi']
+                # JH: Check CPPFLAGS environment variable for include paths
+                if 'MPI_ROOT' in os.environ:
+                    conf.env.INCLUDES_MPI += [os.environ['MPI_ROOT'] +"/include", os.environ['MPI_ROOT'] +"/include64"]
+                elif 'I_MPI_ROOT' in os.environ: 
+                    conf.env.INCLUDES_MPI += [os.environ['I_MPI_ROOT'] +"/include", os.environ['I_MPI_ROOT'] +"/include64"]
+                elif 'CPPFLAGS' in os.environ:
+                    conf.env.INCLUDES_MPI += [path[2:] for path in os.environ['CPPFLAGS'].split() if path[0:2] == '-I']
+                conf.env.INCLUDES_MPI += ['/usr/include/mpi', '/usr/local/include/mpi', '/usr/include', '/usr/local/include']
+                # JH: Check LD_LIBRARY_PATH for library paths
+                if 'LD_LIBRARY_PATH' in os.environ:
+                    conf.env.LIBPATH_MPI += os.environ['LD_LIBRARY_PATH'].split(":")
+                conf.env.LIBPATH_MPI += ['/usr/lib', '/usr/local/lib', '/usr/lib/openmpi']
 
 	try:
 		conf.start_msg('Checking for MPI include')
@@ -38,7 +50,7 @@ def check_mpi(conf):
 		conf.env['MPI_FOUND'] = True
 		conf.env.LIB_MPI = ['mpi_cxx','mpi']
 	except:
-		conf.end_msg('Not found', 'RED')
+		conf.end_msg('Not found', 'YELLOW')
 	return 1
 
 def detect(conf):

--- a/waf_tools/tbb.py
+++ b/waf_tools/tbb.py
@@ -5,7 +5,7 @@
 """
 Quick n dirty tbb detection
 """
-
+import os
 from waflib.Configure import conf
 
 
@@ -15,12 +15,18 @@ def options(opt):
 
 @conf
 def check_tbb(self, *k, **kw):
+    includes_tbb = []
+    libpath_tbb = []
     if self.options.tbb:
-        includes_tbb = [self.options.tbb + '/include']
-        libpath_tbb = [self.options.tbb + '/lib']
+        includes_tbb += [self.options.tbb + '/include']
+        libpath_tbb += [self.options.tbb + '/lib']
     else:
-        includes_tbb = ['/usr/local/include', '/usr/include', '/opt/intel/tbb/include']
-        libpath_tbb = ['/usr/local/lib/', '/usr/lib', '/opt/intel/tbb/lib']
+        includes_tbb += [path[2:] for path in self.env['CPPFLAGS'] if path[0:2] == '-I']
+        if 'CPPFLAGS' in os.environ:
+            includes_tbb += [path[2:] for path in os.environ['CPPFLAGS'].split() if path[0:2] == '-I']
+        if 'LD_LIBRARY_PATH' in os.environ:
+            libpath_tbb += os.environ['LD_LIBRARY_PATH'].split(":")
+        libpath_tbb += ['/usr/local/lib/', '/usr/lib', '/opt/intel/tbb/lib']
 
     self.start_msg('Checking Intel TBB includes')
     try:


### PR DESCRIPTION
Enabled the ability for sferes to automatically detect libraries and header files loaded through the lmod module management system. Has currently only been tested on Mount Moran.

As is clear from the commit history, I had some issues with spaces and tabs. What is the policy regarding tabs and spaces in sferes? 