### PR TITLE
Abs fix for CMAES

### DIFF
--- a/sferes/ea/cmaes.cpp
+++ b/sferes/ea/cmaes.cpp
@@ -2270,7 +2270,7 @@ random_init( random_t *t, long unsigned inseed) {
   if (inseed < 1) {
     while ((long) (cloc - clock()) == 0)
       ; /* TODO: remove this for time critical applications? */
-    inseed = (long unsigned)abs((long)(100*time(NULL)+clock()));
+    inseed = (long unsigned)labs((long)(100*time(NULL)+clock()));
   }
   return random_Start(t, inseed);
 }
@@ -2656,7 +2656,7 @@ readpara_SupplementDefaults(readpara_t *t) {
   if (t->seed < 1) {
     while ((int) (cloc - clock()) == 0)
       ; /* TODO: remove this for time critical applications!? */
-    t->seed = (unsigned int)abs((long)(100*time(NULL)+clock()));
+    t->seed = (unsigned int)labs((long)(100*time(NULL)+clock()));
   }
 
   if (t->stStopFitness.flg == -1)


### PR DESCRIPTION
Silenced warnings by clang that abs is provided long but takes and int by replacing those instances of abs with labs (see issue #44). This also ensures that the correct version of abs is used.