### PR TITLE
Add data getter from float genotype

### DIFF
--- a/sferes/gen/float.hpp
+++ b/sferes/gen/float.hpp
@@ -75,6 +75,9 @@ namespace sferes {
       //@}
 
       //@{
+      const std::vector<float>& data() const {
+        return this->_data;
+      }
       float data(size_t i) const {
         assert(this->_data.size());
         assert(i < this->_data.size());


### PR DESCRIPTION
I often wanted to get all the data of the float genotype. This is why I created this accessor.