### PR TITLE
Fix for SBX when mating with itself

### DIFF
--- a/sferes/gen/evo_float.hpp
+++ b/sferes/gen/evo_float.hpp
@@ -233,6 +233,13 @@ namespace sferes {
                 child2.data(i, c1);
               }
             }
+            else{ 
+              // case where y1 == y2
+              // the two genes are the same (which may come for example,
+              // when the two parents are the same individual)
+              child1.data(i, y1);
+              child2.data(i, y2);
+            }
           }
         }
       };


### PR DESCRIPTION
The current SBX code does not handle the case where the two parents are the same individual. As a result, all the genes of the offspring take the value of 0.5. 

The more general case is when the corresponding genes are shared, which is not handled either (would result in a 0.5 value in that position). The current PR corrects that.