### PR TITLE
fix missing pthread link flag

### DIFF
--- a/wscript
+++ b/wscript
@@ -150,6 +150,11 @@ def configure(conf):
     else:
         conf.env['MPI_ENABLED'] = False
 
+    # PTHREAD 
+    conf.env.LIBPATH_PTHREAD = ['/usr/local/lib/', '/usr/lib', '/usr/lib/x86_64-linux-gnu/']
+    conf.env.LIB_PTHREAD = ['pthread']
+
+
     # eigen 3 (optional)
     conf.load('eigen')
     conf.check_eigen()


### PR DESCRIPTION
Fix discussed in #92 .
It seems to work on OSX (just a small warning ld: warning: directory not found for option '-L/usr/lib/x86_64-linux-gnu/')

 